### PR TITLE
 Fix: Push notification 기능 적용 중, Info.plist 업데이트 누락 푸시로 인한 빌드 불가

### DIFF
--- a/Projects/CodePlay/CodePlay.xcodeproj/project.pbxproj
+++ b/Projects/CodePlay/CodePlay.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		D819C4582E28F6EB009CB69B /* Exceptions for "CodePlay" folder in "CodePlay" target */ = {
+		0996ADCE2E2D21DB00B57383 /* Exceptions for "CodePlay" folder in "CodePlay" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -33,7 +33,7 @@
 		D8391C402E1CC9C000A44C3F /* CodePlay */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				D819C4582E28F6EB009CB69B /* Exceptions for "CodePlay" folder in "CodePlay" target */,
+				0996ADCE2E2D21DB00B57383 /* Exceptions for "CodePlay" folder in "CodePlay" target */,
 			);
 			path = CodePlay;
 			sourceTree = "<group>";
@@ -163,6 +163,7 @@
 				"else",
 				"    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"",
 				"fi",
+				"",
 				"",
 				"",
 				"",

--- a/Projects/CodePlay/CodePlay/Domain/Interfaces/ExportPlaylistRepository.swift
+++ b/Projects/CodePlay/CodePlay/Domain/Interfaces/ExportPlaylistRepository.swift
@@ -116,7 +116,7 @@ final class DefaultExportPlaylistRepository: ExportPlaylistRepository {
                     let trackId = song.id.rawValue
                     let trackTitle = song.title
 
-                    let trackPreviewUrl: String = song.previewAssets?.first?.url.absoluteString ?? ""
+                    let trackPreviewUrl: String = song.previewAssets?.first?.url?.absoluteString ?? ""
                     let albumArtworkUrl: String = song.artwork?.url(width: 300, height: 300)?.absoluteString ?? ""
 
                     let entry = PlaylistEntry(

--- a/Projects/CodePlay/CodePlay/Info.plist
+++ b/Projects/CodePlay/CodePlay/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #34 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
푸시 알림 받으려고 BackgroundModes를 설정하면 자동으로 info.plist가 생성되는데, 그럼 Build Phase의 Copy Bundle Resources에 그 info.plist가 추가가 되어서, 그걸 제거해야 하는 과정이 필요한데, 그걸 해놓고 제가 obj파일이랑 plist를 충돌날까봐 안올려서 Dev에서 문제가 생겼었네요

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 성공 확인

---

### 🙇🏻‍♀️ 리뷰 전 확인해야 할 사항
<!-- PR을 업로드 하기 전에 꼭! 체크해주세요 -->

- [ x ] 코드 컨벤션이 잘 지켜졌나요?
- [ x ] 불필요한 주석, 테스트 코드는 지워져있나요?
- [ x ] 업로드 금지파일이 포함되어있나요?
