### PR TITLE
[FEAT] 플레이리스트 비즈니스 로직 적용 및 시연 

### DIFF
--- a/Projects/CodePlay/CodePlay.xcodeproj/project.pbxproj
+++ b/Projects/CodePlay/CodePlay.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 				"",
 				"",
 				"",
+				"",
 			);
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Projects/CodePlay/CodePlay/Application/DIContainer/AppComponent.swift
+++ b/Projects/CodePlay/CodePlay/Application/DIContainer/AppComponent.swift
@@ -25,13 +25,12 @@ final class AppComponent {
         appDIContainer: appDIContainer, modelContext: modelContext
     )
 
-    func makeRootView() -> some View {
+    @MainActor func makeRootView() -> some View {
         let mainFactory = appFlowCoordinator.mainFlowStart()
         let licenseFactory = appFlowCoordinator.licenseFlowStart()
         let diContainer = appDIContainer.mainSceneDIContainer(modelContext: modelContext)
+        let musicWrapper = diContainer.appleMusicConnectViewModelWrapper()
 
-        let musicWrapper =
-            diContainer.appleMusicConnectViewModelWrapper()
         let posterWraper = diContainer.makePosterViewModelWrapper()
 
         let rootView = MainView(mainFactory: mainFactory, licenseFactory: licenseFactory)

--- a/Projects/CodePlay/CodePlay/Application/DIContainer/MainSceneDIContainer.swift
+++ b/Projects/CodePlay/CodePlay/Application/DIContainer/MainSceneDIContainer.swift
@@ -116,8 +116,7 @@ final class MainSceneDIContainer {
     // MARK: ViewModelWrapper
     func makePosterViewModelWrapper() -> PosterViewModelWrapper {
         return PosterViewModelWrapper(
-            viewModel: makePosterViewModel(),
-            playlist: Playlist(title: "")
+            viewModel: makePosterViewModel()
         )
     }
 

--- a/Projects/CodePlay/CodePlay/Domain/Interfaces/ExportPlaylistRepository.swift
+++ b/Projects/CodePlay/CodePlay/Domain/Interfaces/ExportPlaylistRepository.swift
@@ -117,7 +117,7 @@ final class DefaultExportPlaylistRepository: ExportPlaylistRepository {
                 for song in topSongs {
                     let entry = PlaylistEntry(
                         id: UUID(),
-                        playlistId: UUID(), // 나중에 덮어씌움
+                        playlistId: UUID(), // 추후 ViewModel에서 덮어씌움
                         artistMatchId: artist.id,
                         artistName: artist.artistName,
                         appleMusicId: artist.appleMusicId,
@@ -141,6 +141,7 @@ final class DefaultExportPlaylistRepository: ExportPlaylistRepository {
         print("✅ [searchTopSongs] 총 생성된 Entry 수: \(allEntries.count)")
         return allEntries
     }
+
 
 
     // 영구 저장소에 Playlist 및 해당 Entry 저장

--- a/Projects/CodePlay/CodePlay/Domain/Interfaces/ExportPlaylistRepository.swift
+++ b/Projects/CodePlay/CodePlay/Domain/Interfaces/ExportPlaylistRepository.swift
@@ -112,38 +112,36 @@ final class DefaultExportPlaylistRepository: ExportPlaylistRepository {
                 let response = try await request.response()
                 let topSongs = response.songs.prefix(3)
 
+                print("🔍 [TopSongs] \(artist.artistName) - 검색된 곡 수: \(topSongs.count)")
+
                 for song in topSongs {
-                    let trackId = song.id.rawValue
-                    let trackTitle = song.title
-
-                    let trackPreviewUrl: String = song.previewAssets?.first?.url?.absoluteString ?? ""
-                    let albumArtworkUrl: String = song.artwork?.url(width: 300, height: 300)?.absoluteString ?? ""
-                    let albumName = song.albumTitle ?? "Unknown Album"
-
                     let entry = PlaylistEntry(
                         id: UUID(),
-                        playlistId: UUID(), // save 시 덮어씌움
+                        playlistId: UUID(), // 나중에 덮어씌움
                         artistMatchId: artist.id,
                         artistName: artist.artistName,
                         appleMusicId: artist.appleMusicId,
-                        trackTitle: trackTitle,
-                        trackId: trackId,
-                        trackPreviewUrl: trackPreviewUrl,
+                        trackTitle: song.title,
+                        trackId: song.id.rawValue,
+                        trackPreviewUrl: song.previewAssets?.first?.url?.absoluteString ?? "",
                         profileArtworkUrl: artist.profileArtworkUrl,
-                        albumArtworkUrl: albumArtworkUrl,
-                        albumName: albumName,
+                        albumArtworkUrl: song.artwork?.url(width: 300, height: 300)?.absoluteString ?? "",
+                        albumName: song.albumTitle ?? "Unknown Album",
                         createdAt: .now
                     )
 
+                    print("🎵 [Entry 생성됨] \(entry.artistName) - \(entry.trackTitle) (\(entry.trackId))")
                     allEntries.append(entry)
                 }
             } catch {
-                print("❌ \(artist.artistName) 인기곡 검색 실패: \(error)")
+                print("❌ [TopSongs 검색 실패] \(artist.artistName): \(error)")
             }
         }
 
+        print("✅ [searchTopSongs] 총 생성된 Entry 수: \(allEntries.count)")
         return allEntries
     }
+
 
     // 영구 저장소에 Playlist 및 해당 Entry 저장
     @MainActor

--- a/Projects/CodePlay/CodePlay/Domain/Models/Playlist.swift
+++ b/Projects/CodePlay/CodePlay/Domain/Models/Playlist.swift
@@ -12,6 +12,7 @@ final class Playlist {
     @Attribute(.unique) var id: UUID
     var title: String
     var createdAt: Date
+    @Relationship(deleteRule: .cascade, inverse: \PlaylistEntry.playlist)
     var entries: [PlaylistEntry] = []
     var period: String?
     var cast: String?

--- a/Projects/CodePlay/CodePlay/Domain/Models/PlaylistEntry.swift
+++ b/Projects/CodePlay/CodePlay/Domain/Models/PlaylistEntry.swift
@@ -22,6 +22,7 @@ final class PlaylistEntry {
     var albumArtworkUrl: String
     var albumName: String
     var createdAt: Date
+    @Relationship var playlist: Playlist? 
 
     init(
         id: UUID = UUID(),

--- a/Projects/CodePlay/CodePlay/Domain/Usecases/ExportPlaylistUseCase.swift
+++ b/Projects/CodePlay/CodePlay/Domain/Usecases/ExportPlaylistUseCase.swift
@@ -29,13 +29,7 @@ final class DefaultExportPlaylistUseCase: ExportPlaylistUseCase {
     }
 
     func searchTopSongs(from rawText: RawText, artistMatches: [ArtistMatch]) async throws -> [PlaylistEntry] {
-        let title = rawText.text.components(separatedBy: .newlines).first ?? "My Playlist"
-        let entries = await repository.searchTopSongs(for: artistMatches)
-
-        try await repository.savePlaylist(title: title, entries: entries)
-        repository.clearTemporaryData()
-
-        return entries
+        return await repository.searchTopSongs(for: artistMatches)
     }
     
     func exportToAppleMusic(playlist: Playlist, entries: [PlaylistEntry]) async throws {

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportPlaylistView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportPlaylistView.swift
@@ -62,9 +62,10 @@ struct ExportPlaylistView: View {
         .backgroundWithBlur()
         .navigationBarBackButtonHidden(true)
         .onAppear {
-            let fakeRawText = RawText(text: selectedArtists.joined(separator: ", "))
-            wrapper.onAppear(with: fakeRawText)
+            Task {
+                let rawText = RawText(text: selectedArtists.joined(separator: ", "))
+                await wrapper.onAppear(with: rawText)
+            }
         }
     }
-
 }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportPlaylistView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportPlaylistView.swift
@@ -15,6 +15,8 @@ struct ExportPlaylistView: View {
     @EnvironmentObject var wrapper: MusicViewModelWrapper
     let selectedArtists: [String]
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.modelContext) private var modelContext
+
 
     init(selectedArtists: [String]) {
         self.selectedArtists = selectedArtists
@@ -64,7 +66,7 @@ struct ExportPlaylistView: View {
         .onAppear {
             Task {
                 let rawText = RawText(text: selectedArtists.joined(separator: ", "))
-                await wrapper.onAppear(with: rawText)
+                await wrapper.onAppear(with: rawText, using: modelContext)
             }
         }
     }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportPlaylistView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportPlaylistView.swift
@@ -16,12 +16,13 @@ struct ExportPlaylistView: View {
     let selectedArtists: [String]
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.modelContext) private var modelContext
+    let playlist: Playlist
 
-
-    init(selectedArtists: [String]) {
+    init(selectedArtists: [String], playlist: Playlist) {
         self.selectedArtists = selectedArtists
+        self.playlist = playlist
     }
-
+    
     var body: some View {
         VStack(spacing: 20) {
             Spacer(minLength: 0)
@@ -66,7 +67,7 @@ struct ExportPlaylistView: View {
         .onAppear {
             Task {
                 let rawText = RawText(text: selectedArtists.joined(separator: ", "))
-                await wrapper.onAppear(with: rawText, using: modelContext)
+                await wrapper.onAppear(with: rawText, for: playlist, using: modelContext)
             }
         }
     }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportSuccessView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportSuccessView.swift
@@ -11,6 +11,12 @@ import SwiftUI
 struct ExportSuccessView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var posterWrapper: PosterViewModelWrapper
+    @EnvironmentObject var musicWrapper: MusicViewModelWrapper
+    @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.modelContext) private var modelContext
+    @State private var isFullScreenToMainPoster = false
+
     
     var body: some View {
         NavigationStack {
@@ -49,6 +55,11 @@ struct ExportSuccessView: View {
                     .padding(.bottom, 16)
                 }
             }
+            .fullScreenCover(isPresented: $isFullScreenToMainPoster) {
+                MainPosterView()
+                    .environmentObject(posterWrapper)
+                    .environmentObject(musicWrapper)
+            }
             .navigationBarBackButtonHidden(true)
             .navigationBarHidden(false)
             .toolbar {
@@ -56,12 +67,13 @@ struct ExportSuccessView: View {
                     Button(action: {
                         posterWrapper.shouldNavigateToMakePlaylist = false
                         posterWrapper.viewModel.clearText()
-                        dismiss()
-                    }) {
+
+                        isFullScreenToMainPoster = true // ✅ fullScreenCover 트리거
+                    }, label: {
                         Image(systemName: "xmark")
                             .foregroundColor(.neu900)
                             .font(.system(size: 16, weight: .medium))
-                    }
+                    })
                 }
             }
             .toolbarBackground(.hidden, for: .navigationBar)

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportSuccessView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportSuccessView.swift
@@ -15,7 +15,7 @@ struct ExportSuccessView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.modelContext) private var modelContext
-    @State private var isFullScreenToMainPoster = false
+    @State private var isNavigateToMainPoster = false
 
     
     var body: some View {
@@ -54,11 +54,16 @@ struct ExportSuccessView: View {
                     .padding(.horizontal, 20)
                     .padding(.bottom, 16)
                 }
-            }
-            .fullScreenCover(isPresented: $isFullScreenToMainPoster) {
-                MainPosterView()
-                    .environmentObject(posterWrapper)
-                    .environmentObject(musicWrapper)
+                NavigationLink(
+                    destination: MainPosterView()
+                        .environmentObject(posterWrapper)
+                        .environmentObject(musicWrapper),
+                    isActive: $isNavigateToMainPoster
+                ) {
+                    EmptyView()
+                }
+                .hidden()
+
             }
             .navigationBarBackButtonHidden(true)
             .navigationBarHidden(false)
@@ -68,7 +73,9 @@ struct ExportSuccessView: View {
                         posterWrapper.shouldNavigateToMakePlaylist = false
                         posterWrapper.viewModel.clearText()
 
-                        isFullScreenToMainPoster = true // ✅ fullScreenCover 트리거
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            isNavigateToMainPoster = true
+                        }
                     }, label: {
                         Image(systemName: "xmark")
                             .foregroundColor(.neu900)

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/FestivalCheck/FestivalSearchView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/FestivalCheck/FestivalSearchView.swift
@@ -259,6 +259,7 @@ struct SearchTextField: View {
                 .focused($isSearchFocused)
                 .textFieldStyle(PlainTextFieldStyle())
                 .font(.BmdRegular())
+                .submitLabel(.search)
                 .onSubmit {
                     onSearchSubmit()
                 }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/FestivalCheck/SelectArtistView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/FestivalCheck/SelectArtistView.swift
@@ -80,7 +80,10 @@ struct SelectArtistView: View {
             fetchArtistArtworks()
         }
         .navigationDestination(isPresented: $isNextActive) {
-            ExportPlaylistView(selectedArtists: Array(selectedArtists))
+            ExportPlaylistView(
+                selectedArtists: Array(selectedArtists),
+                playlist: playlist
+            )
         }
     }
     

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/PlaylistDetailView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/PlaylistDetailView.swift
@@ -1,0 +1,39 @@
+//
+//  PlaylistDetailView.swift
+//  CodePlay
+//
+//  Created by 성현 on 7/29/25.
+//
+
+import SwiftUI
+import SwiftData
+
+struct PlaylistDetailView: View {
+    let playlist: Playlist
+    @EnvironmentObject var wrapper: MusicViewModelWrapper
+    @Query var allEntries: [PlaylistEntry]
+
+    var body: some View {
+        let entries = allEntries.filter { $0.playlistId == playlist.id }
+        let groupedEntries = Dictionary(grouping: entries, by: { $0.artistName })
+
+        VStack {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    ForEach(groupedEntries.keys.sorted(), id: \.self) { artist in
+                        PlaylistSectionView(artist: artist, entries: groupedEntries[artist] ?? [], wrapper: wrapper)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 20)
+                .padding(.bottom, 80)
+            }
+
+            Text("총 \(entries.count)곡")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+        }
+        .navigationTitle(playlist.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/PlaylistSectionView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/PlaylistSectionView.swift
@@ -20,7 +20,7 @@ struct PlaylistSectionView: View {
         ) {
             ForEach(entries) { entry in
                 CustomList(
-                    imageUrl: entry.albumArtworkUrl,
+                    imageUrl: entry.albumArtworkUrl ?? "",
                     title: entry.trackTitle,
                     albumName: entry.albumName,
                     trackId: entry.trackId,

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/FestivalCheckViewModel.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/FestivalCheckViewModel.swift
@@ -28,7 +28,6 @@ protocol FestivalCheckViewModel: FestivalCheckViewModelInput,
 {}
 
 // MARK: - Implementation
-@MainActor
 final class DefaultFestivalCheckViewModel: FestivalCheckViewModel {
     @Published private(set) var festivalData = Observable<DynamoDataItem?>(nil)
     @Published var suggestTitles = Observable<[String]>([])

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
@@ -181,7 +181,7 @@
         }
 
         // MARK: - Main Flow (Refactored)
-        func onAppear(with rawText: RawText?, using context: ModelContext) async {
+        func onAppear(with rawText: RawText?, for playlist: Playlist, using context: ModelContext) async {
             guard let rawText else { return }
             print("🟠 [onAppear] rawText: \(rawText.text)")
 
@@ -204,7 +204,7 @@
             playlistEntries = songs
             print("📦 [playlistEntries 저장 완료] \(playlistEntries.count)곡")
 
-            await savePlaylistAfterTopSongs(title: "내가 고른 아티스트", context: context)
+            await savePlaylistAfterTopSongs(playlist: playlist, context: context)
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                 withAnimation(.easeInOut(duration: 0.3)) {
@@ -215,23 +215,19 @@
 
 
         // MARK: - Save to SwiftData
-        func savePlaylistAfterTopSongs(title: String, context: ModelContext) async {
+        func savePlaylistAfterTopSongs(playlist: Playlist, context: ModelContext) async {
             guard !playlistEntries.isEmpty else {
                 print("❌ 저장 시도했지만 playlistEntries가 비어 있음")
                 return
             }
 
-            let playlistId = UUID()
-            let playlist = Playlist(id: playlistId, title: title, createdAt: .now)
-
-            context.insert(playlist)
+            let playlistId = playlist.id
 
             for entry in playlistEntries {
                 guard !entry.trackId.isEmpty else {
                     print("⚠️ 잘못된 Entry - trackId 없음: \(entry.artistName)")
                     continue
                 }
-
                 entry.playlistId = playlistId
                 context.insert(entry)
 
@@ -240,11 +236,12 @@
 
             do {
                 try context.save()
-                print("✅ ExportPlaylistView에서 Playlist 저장 완료")
+                print("✅ 기존 Playlist에 Entry 추가 완료")
             } catch {
                 print("❌ 저장 실패: \(error)")
             }
         }
+
 
         // MARK: - Export
         func exportToAppleMusic() {

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
@@ -204,8 +204,11 @@
 
             withAnimation(.easeInOut(duration: 1.2)) { progressStep = 3 }
 
-            playlistEntries = songs
-            print("📦 [playlistEntries 저장 완료] \(playlistEntries.count)곡")
+            await MainActor.run {
+                self.playlistEntries = songs
+                print("📦 [playlistEntries 저장 완료] \(songs.count)곡")
+            }
+ 
 
             await savePlaylistAfterTopSongs(playlist: playlist, context: context)
 

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
@@ -143,7 +143,10 @@
 
         // MARK: - Binding Observables
         private func bind() {
-            festivalCheckViewModel.isLoading.observe(on: self) { [weak self] in self?.isLoading = $0 }
+            festivalCheckViewModel.isLoading.observe(on: self) { [weak self] value in
+                guard let self else { return }
+                self.isLoading = value
+            }
             festivalCheckViewModel.festivalData.observe(on: self) { [weak self] in self?.festivalData = $0 }
             festivalCheckViewModel.suggestTitles.observe(on: self) { [weak self] in self?.suggestTitles = $0 }
 

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
@@ -1,285 +1,266 @@
-//
-//  AppleMusicConnectView.swift
-//  CodePlay
-//
-//  Created by 성현 on 7/15/25.
-//
+    //
+    //  AppleMusicConnectView.swift
+    //  CodePlay
+    //
+    //  Created by 성현 on 7/15/25.
+    //
 
-internal import Combine
-import MusicKit
-import SwiftUI
+    internal import Combine
+    import MusicKit
+    import SwiftUI
+    import SwiftData
 
-struct AppleMusicConnectView: View {
-    @EnvironmentObject var viewModelWrapper: MusicViewModelWrapper
-    @State private var showingSettings = false
+    struct AppleMusicConnectView: View {
+        @EnvironmentObject var viewModelWrapper: MusicViewModelWrapper
+        @State private var showingSettings = false
 
-    var body: some View {
-        VStack(spacing: 0) {
-            // 상단 여백 (Safe Area 고려하여 조정)
-            Spacer().frame(height: 96)
+        var body: some View {
+            VStack(spacing: 0) {
+                // 상단 여백 (Safe Area 고려하여 조정)
+                Spacer().frame(height: 96)
 
-            if viewModelWrapper.authorizationStatus?.status == .denied {
-                Image("Linkfail")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 320, height: 320)
-            } else {
-                Image("Linkapplemusic")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 320, height: 320)
-            }
+                if viewModelWrapper.authorizationStatus?.status == .denied {
+                    Image("Linkfail")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 320, height: 320)
+                } else {
+                    Image("Linkapplemusic")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 320, height: 320)
+                }
 
-            // 사각형과 제목 사이 간격
-            Spacer().frame(height: 32)
+                // 사각형과 제목 사이 간격
+                Spacer().frame(height: 32)
 
-            VStack(spacing : 12){
-                Text("Apple Music을\n연결해주세요")
-                    .font(.HlgBold())
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(Color.neu900)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                
-                Text("페스티벌 플레이리스트 생성을 위해\nApple Music을 연결해주세요.")
-                    .font(.BmdRegular())
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(Color.neu700)
-                    .padding(.horizontal, 32)
-            }
-
-            Spacer()
-
-            // 4. 연결 버튼 또는 설정 안내 (하단에서 적절한 위치에 배치)
-            if viewModelWrapper.authorizationStatus?.status == .denied {
-                // 권한 거부 시 설정 안내
-                VStack(spacing: 16) {
-                    Text("설정에서 권한을 허용해주세요")
-                        .font(Font.custom("KoddiUD OnGothic", size: 18))
-                        .foregroundColor(.red)
+                VStack(spacing : 12){
+                    Text("Apple Music을\n연결해주세요")
+                        .font(.HlgBold())
                         .multilineTextAlignment(.center)
+                        .foregroundColor(Color.neu900)
+                        .frame(maxWidth: .infinity, alignment: .center)
                     
-                    BottomButton(title: "설정으로 이동", kind: .line) {
-                        viewModelWrapper.appleMusicConnectViewModel.shouldOpenSettings.value = true
+                    Text("페스티벌 플레이리스트 생성을 위해\nApple Music을 연결해주세요.")
+                        .font(.BmdRegular())
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(Color.neu700)
+                        .padding(.horizontal, 32)
+                }
+
+                Spacer()
+
+                // 4. 연결 버튼 또는 설정 안내 (하단에서 적절한 위치에 배치)
+                if viewModelWrapper.authorizationStatus?.status == .denied {
+                    // 권한 거부 시 설정 안내
+                    VStack(spacing: 16) {
+                        Text("설정에서 권한을 허용해주세요")
+                            .font(Font.custom("KoddiUD OnGothic", size: 18))
+                            .foregroundColor(.red)
+                            .multilineTextAlignment(.center)
+                        
+                        BottomButton(title: "설정으로 이동", kind: .line) {
+                            viewModelWrapper.appleMusicConnectViewModel.shouldOpenSettings.value = true
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.horizontal, 16)
                     }
-                    .padding(.horizontal, 20)
+                } else {
+                    BottomButton(
+                        title: "Apple Music에 연결",
+                        kind: .line,
+                        action: {
+                            Task {
+                                // 권한 요청
+                                viewModelWrapper.appleMusicConnectViewModel.shouldRequestMusicAuthorization.value = true
+                            }
+                        }
+                    )
                     .padding(.horizontal, 16)
                 }
-            } else {
-                BottomButton(
-                    title: "Apple Music에 연결",
-                    kind: .line,
-                    action: {
-                        Task {
-                            // 권한 요청
-                            viewModelWrapper.appleMusicConnectViewModel.shouldRequestMusicAuthorization.value = true
-                        }
-                    }
-                )
-                .padding(.horizontal, 16)
-            }
 
-            // 에러 메시지 표시
-            if let errorMessage = viewModelWrapper.errorMessage {
-                Text(errorMessage)
-                    .font(.BmdRegular())
-                    .foregroundColor(.red)
-                    .padding(.horizontal, 16)
-                    .padding(.top, 16)
-                    .multilineTextAlignment(.center)
-            }
+                // 에러 메시지 표시
+                if let errorMessage = viewModelWrapper.errorMessage {
+                    Text(errorMessage)
+                        .font(.BmdRegular())
+                        .foregroundColor(.red)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 16)
+                        .multilineTextAlignment(.center)
+                }
 
-            // 하단 여백 (Home Indicator 고려)
-            Spacer().frame(height: 100)
+                // 하단 여백 (Home Indicator 고려)
+                Spacer().frame(height: 100)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.white)
+            .ignoresSafeArea(.all, edges: .bottom)  // 하단 Safe Area 무시
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.white)
-        .ignoresSafeArea(.all, edges: .bottom)  // 하단 Safe Area 무시
     }
-}
 
-// MARK: - ViewModelWrapper for ObservableObject compatibility
-final class MusicViewModelWrapper: ObservableObject {
-    @Published var authorizationStatus: MusicAuthorizationStatusModel?
-    @Published var subscriptionStatus: MusicSubscriptionModel?
-    @Published var errorMessage: String?
-    @Published var canPlayMusic: Bool = false
-    @Published var artistCandidates: [String] = []
-    /// 현재 프로세스 단계 (0: 대기, 1: 아티스트 탐색 시작, 2: 아티스트 탐색 완료, 3: 인기곡 추출 완료)
-    @Published var progressStep: Int = 0
-    /// 플레이리스트 생성 완료 후 MadePlaylistView로의 네비게이션 트리거
-    @Published var navigateToMadePlaylist: Bool = false
-    /// Apple Music으로 내보내기 중인지 여부
-    @Published var isExporting: Bool = false
-    /// Apple Music 내보내기 완료 여부
-    @Published var isExportCompleted: Bool = false
-    /// 완성된 플레이리스트 엔트리 목록
-    @Published var playlistEntries: [PlaylistEntry] = []
-    /// 현재 재생 중인 곡의 ID (30초 미리듣기용)
-    @Published var currentlyPlayingTrackId: String?
-    /// 재생 상태 (재생 중/일시정지)
-    @Published var isPlaying: Bool = false
-    /// 재생 진행률 (0.0 ~ 1.0, 30초 기준)
-    @Published var playbackProgress: Double = 0.0
-    @Published var isLoading: Bool = true  // 로딩 상태 추가
-    @Published var festivalData: DynamoDataItem? = nil
-    @Published var suggestTitles: [String] = []
+    // MARK: - ViewModelWrapper for ObservableObject compatibility
+    final class MusicViewModelWrapper: ObservableObject {
+        // MARK: - Published Properties
+        @Published var authorizationStatus: MusicAuthorizationStatusModel?
+        @Published var subscriptionStatus: MusicSubscriptionModel?
+        @Published var errorMessage: String?
+        @Published var canPlayMusic: Bool = false
+        @Published var artistCandidates: [String] = []
+        @Published var progressStep: Int = 0
+        @Published var navigateToMadePlaylist: Bool = false
+        @Published var isExporting: Bool = false
+        @Published var isExportCompleted: Bool = false
+        @Published var playlistEntries: [PlaylistEntry] = []
+        @Published var currentlyPlayingTrackId: String?
+        @Published var isPlaying: Bool = false
+        @Published var playbackProgress: Double = 0.0
+        @Published var isLoading: Bool = true
+        @Published var festivalData: DynamoDataItem? = nil
+        @Published var suggestTitles: [String] = []
 
+        @Environment(\.modelContext) private var modelContext
 
-    var appleMusicConnectViewModel: any AppleMusicConnectViewModel
-    var exportViewModelWrapper: any ExportPlaylistViewModel
-    var festivalCheckViewModel: any FestivalCheckViewModel
+        // MARK: - Dependencies
+        var appleMusicConnectViewModel: any AppleMusicConnectViewModel
+        var exportViewModelWrapper: any ExportPlaylistViewModel
+        var festivalCheckViewModel: any FestivalCheckViewModel
+        private var musicPlayerUseCase: MusicPlayerUseCase
 
-    /// MusicPlayer UseCase (Clean Architecture 적용)
-    private var musicPlayerUseCase: MusicPlayerUseCase
+        // MARK: - Init
+        init(
+            appleMusicConnectViewModel: any AppleMusicConnectViewModel,
+            exportViewModelWrapper: any ExportPlaylistViewModel,
+            festivalCheckViewModel: any FestivalCheckViewModel,
+            musicPlayerUseCase: MusicPlayerUseCase
+        ) {
+            self.appleMusicConnectViewModel = appleMusicConnectViewModel
+            self.exportViewModelWrapper = exportViewModelWrapper
+            self.festivalCheckViewModel = festivalCheckViewModel
+            self.musicPlayerUseCase = musicPlayerUseCase
 
-    init(appleMusicConnectViewModel: any AppleMusicConnectViewModel, exportViewModelWrapper: any ExportPlaylistViewModel, festivalCheckViewModel: any FestivalCheckViewModel, musicPlayerUseCase: MusicPlayerUseCase) {
-        self.appleMusicConnectViewModel = appleMusicConnectViewModel
-        self.exportViewModelWrapper = exportViewModelWrapper
-        self.festivalCheckViewModel = festivalCheckViewModel
-        self.musicPlayerUseCase = musicPlayerUseCase
-        
+            bind()
+        }
 
-        // UseCase를 통해 Repository 콜백 설정
-        self.musicPlayerUseCase.setupRepositoryCallbacks(
-            onPlaybackStateChanged: { [weak self] trackId, isPlaying in
+        // MARK: - Binding Observables
+        private func bind() {
+            festivalCheckViewModel.isLoading.observe(on: self) { [weak self] in self?.isLoading = $0 }
+            festivalCheckViewModel.festivalData.observe(on: self) { [weak self] in self?.festivalData = $0 }
+            festivalCheckViewModel.suggestTitles.observe(on: self) { [weak self] in self?.suggestTitles = $0 }
+
+            appleMusicConnectViewModel.authorizationStatus.observe(on: self) { [weak self] status in
                 DispatchQueue.main.async {
+                    self?.authorizationStatus = status
+                    self?.canPlayMusic = (status?.status == .authorized)
+                }
+            }
+
+            appleMusicConnectViewModel.subscriptionStatus.observe(on: self) { [weak self] in self?.subscriptionStatus = $0 }
+            appleMusicConnectViewModel.errorMessage.observe(on: self) { [weak self] in self?.errorMessage = $0 }
+            appleMusicConnectViewModel.canPlayMusic.observe(on: self) { [weak self] newValue in
+                guard let self = self else { return }
+                if self.canPlayMusic != newValue {
+                    DispatchQueue.main.async {
+                        self.canPlayMusic = newValue
+                    }
+                }
+            }
+
+
+            exportViewModelWrapper.artistCandidates.observe(on: self) { [weak self] in self?.artistCandidates = $0 }
+
+            musicPlayerUseCase.setupRepositoryCallbacks(
+                onPlaybackStateChanged: { [weak self] trackId, isPlaying in
                     self?.currentlyPlayingTrackId = trackId
                     self?.isPlaying = isPlaying
-                }
-            },
-            onProgressChanged: { [weak self] progress in
-                print("🎯 [MusicViewModelWrapper] 진행률 받음: \(progress)")
-                DispatchQueue.main.async {
+                },
+                onProgressChanged: { [weak self] progress in
+                    print("🎯 [MusicViewModelWrapper] 진행률: \(progress)")
                     self?.playbackProgress = progress
-                    print("🎯 [MusicViewModelWrapper] UI 진행률 업데이트 완료: \(self?.playbackProgress ?? 0)")
                 }
-            }
-        )
-        
-        festivalCheckViewModel.isLoading.observe(on: self) { [weak self] newData in
-            self?.isLoading = newData
-        }
-        
-        festivalCheckViewModel.festivalData.observe(on: self) { [weak self] newData in
-            self?.festivalData = newData
+            )
         }
 
-        festivalCheckViewModel.suggestTitles.observe(on: self) { [weak self] newData in
-            print("🎯 suggestTitles 업데이트 감지: \(newData)")
-            self?.suggestTitles = newData
-        }
-        
-        appleMusicConnectViewModel.authorizationStatus.observe(on: self) { [weak self] status in
-            DispatchQueue.main.async {
-                self?.authorizationStatus = status
-                
-                if status?.status == .authorized {
-                    self?.canPlayMusic = true
-                } else {
-                    self?.canPlayMusic = false
-                }
-            }
-        }
+        // MARK: - Main Flow (Refactored)
+        func onAppear(with rawText: RawText?) async {
+            guard let rawText else { return }
+            print("🟠 Wrapper.onAppear - rawText: \(rawText.text)")
+            progressStep = 0
 
-        appleMusicConnectViewModel.subscriptionStatus.observe(on: self) { [weak self] subscription in
-            DispatchQueue.main.async {
-                self?.subscriptionStatus = subscription
-            }
-        }
+            exportViewModelWrapper.preProcessRawText(rawText)
+            withAnimation(.easeInOut(duration: 0.5)) { progressStep = 1 }
 
-        appleMusicConnectViewModel.errorMessage.observe(on: self) { [weak self] error in
-            DispatchQueue.main.async {
-                self?.errorMessage = error
-            }
-        }
-
-        appleMusicConnectViewModel.canPlayMusic.observe(on: self) { [weak self] canPlay in
-            DispatchQueue.main.async {
-                self?.canPlayMusic = canPlay
-            }
-        }
-        
-        exportViewModelWrapper.artistCandidates.observe(on: self) { [weak self] candidates in
-            self?.artistCandidates = candidates
-        }
-    }
-    /// View가 나타날 때 호출되는 함수
-    /// - OCR로부터 받은 RawText를 바탕으로 전체 흐름 수행
-    func onAppear(with rawText: RawText?) {
-        guard let rawText else { return }
-
-        progressStep = 0
-
-        // 1단계: 텍스트 전처리 (후보 아티스트 추출)
-        exportViewModelWrapper.preProcessRawText(rawText)
-        withAnimation(.easeInOut(duration: 0.5)) {
-            progressStep = 1
-        }
-
-        Task {
-            // 2단계: 아티스트 검색
             let matches = await exportViewModelWrapper.searchArtists(from: rawText)
-            DispatchQueue.main.async {
-                withAnimation(.easeInOut(duration: 0.5)) {
-                    self.progressStep = 2
-                }
-                matches.forEach { print("✅ \( $0.artistName ) (\($0.appleMusicId))") }
-            }
+            withAnimation(.easeInOut(duration: 0.5)) { progressStep = 2 }
+            matches.forEach { print("✅ \($0.artistName) (\($0.appleMusicId))") }
 
-            // 3단계: 아티스트별 상위 곡 검색
             let songs = await exportViewModelWrapper.searchTopSongs(from: rawText, artistMatches: matches)
-            DispatchQueue.main.async {
-                withAnimation(.easeInOut(duration: 1.2)) {
-                    self.progressStep = 3
-                }
-                
-                self.playlistEntries = songs
-                for entry in songs {
-                    print("🎵 \(entry.artistName) - \(entry.trackTitle)")
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                    withAnimation(.easeInOut(duration: 0.3)) {
-                        self.navigateToMadePlaylist = true
-                    }
-                }
-            }
-        }
-    }
-    
-    /// Apple Music으로 플레이리스트를 내보내는 트리거 함수
-    func exportToAppleMusic() {
-        isExporting = true
+            withAnimation(.easeInOut(duration: 1.2)) { progressStep = 3 }
 
-        Task {
-            await exportViewModelWrapper.exportLatestPlaylistToAppleMusic()
-
-            // 내보내기 완료 후 상태 업데이트 (5초 후 완료 상태 전환)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                self.isExporting = false
-                self.isExportCompleted = true
+            playlistEntries = songs
+            for entry in songs {
+                print("🎵 \(entry.artistName) - \(entry.trackTitle)")
             }
-        }
-    }
-    
-    /// 플레이리스트에서 특정 곡 삭제
-    func deleteEntry(at indexSet: IndexSet) {
-        playlistEntries.remove(atOffsets: indexSet)
-        
-        // 삭제된 곡이 현재 재생 중이었다면 재생 중지
-        if let playingTrackId = currentlyPlayingTrackId {
-            let remainingTrackIds = playlistEntries.map { $0.trackId }
-            if !remainingTrackIds.contains(playingTrackId) {
-                Task {
-                    await musicPlayerUseCase.musicRepository.stopPreview()
+
+            await savePlaylistAfterTopSongs(title: "내가 고른 아티스트")
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    self.navigateToMadePlaylist = true
                 }
             }
         }
-    }
-    
-    /// 30초 미리듣기 재생/일시정지 토글
-    func togglePreview(for trackId: String) {
-        Task {
-            await musicPlayerUseCase.musicRepository.togglePreview(for: trackId)
+
+        // MARK: - Save to SwiftData
+        func savePlaylistAfterTopSongs(title: String) async {
+            guard !playlistEntries.isEmpty else {
+                print("❌ 저장 시도했지만 playlistEntries가 비어 있음")
+                return
+            }
+
+            let playlistId = UUID()
+            let playlist = Playlist(id: playlistId, title: title, createdAt: .now)
+            modelContext.insert(playlist)
+
+            for entry in playlistEntries {
+                guard !entry.trackId.isEmpty else {
+                    print("⚠️ 잘못된 Entry - trackId 없음: \(entry.artistName)")
+                    continue
+                }
+                print("📦 저장할 Entry: \(entry.artistName) - \(entry.trackTitle) / \(entry.trackId)")
+                entry.playlistId = playlistId
+                modelContext.insert(entry)
+            }
+
+            do {
+                try modelContext.save()
+                print("✅ ExportPlaylistView에서 Playlist 저장 완료")
+            } catch {
+                print("❌ 저장 실패: \(error)")
+            }
+        }
+
+        // MARK: - Export
+        func exportToAppleMusic() {
+            isExporting = true
+            Task {
+                await exportViewModelWrapper.exportLatestPlaylistToAppleMusic()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                    self.isExporting = false
+                    self.isExportCompleted = true
+                }
+            }
+        }
+
+        // MARK: - Playback Controls
+        func deleteEntry(at indexSet: IndexSet) {
+            playlistEntries.remove(atOffsets: indexSet)
+            if let playingTrackId = currentlyPlayingTrackId,
+               !playlistEntries.map({ $0.trackId }).contains(playingTrackId) {
+                Task { await musicPlayerUseCase.musicRepository.stopPreview() }
+            }
+        }
+
+        func togglePreview(for trackId: String) {
+            Task { await musicPlayerUseCase.musicRepository.togglePreview(for: trackId) }
         }
     }
-}

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
@@ -13,7 +13,7 @@ struct MainPosterView: View {
     @EnvironmentObject var wrapper: PosterViewModelWrapper
     @EnvironmentObject var musicWrapper: MusicViewModelWrapper
     @State private var recognizedText: String = ""
-    @State private var isNavigateToScanPoster = false
+    @State private var isNavigateToScanPoster = false//ㅂ
     @Environment(\.modelContext) var modelContext
     @Query(sort: \Playlist.createdAt, order: .reverse) private var playlists: [Playlist]
     

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
@@ -15,6 +15,7 @@ struct MainPosterView: View {
     @State private var recognizedText: String = ""
     @State private var isNavigateToScanPoster = false
     @Environment(\.modelContext) var modelContext
+    @Query(sort: \Playlist.createdAt, order: .reverse) private var playlists: [Playlist]
     
     var body: some View {
 //        NavigationStack(path: $navigationPath) {
@@ -26,7 +27,7 @@ struct MainPosterView: View {
                 VStack(spacing: 0) {
                     Spacer().frame(height: 60)
             
-                    if wrapper.playlist.isEmpty {
+                    if playlists.isEmpty {
                         VStack(alignment: .center) {
                             Image("Mainempty")
                                 .resizable()
@@ -42,9 +43,8 @@ struct MainPosterView: View {
 
                     } else {
                         VStack {
-                            OverlappingCardsView(playlists: [wrapper.playlist])
-                            
-                            Spacer().frame(height: 12)
+                            OverlappingCardsView(playlists: playlists)
+                            .padding(.bottom, 12)
                         }
                     }
                     

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
@@ -45,7 +45,7 @@ struct MainPosterView: View {
 
                     } else {
                         VStack {
-                            OverlappingCardsView(playlists: playlists)
+                            OverlappingCardsView(playlists: playlists, wrapper: musicWrapper) //임시입니다
                             .padding(.bottom, 12)
                         }
                     }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
@@ -17,6 +17,8 @@ struct MainPosterView: View {
     @Environment(\.modelContext) var modelContext
     @Query(sort: \Playlist.createdAt, order: .reverse) private var playlists: [Playlist]
     
+    
+    
     var body: some View {
 //        NavigationStack(path: $navigationPath) {
             ZStack(alignment: .bottom) {
@@ -83,6 +85,12 @@ struct MainPosterView: View {
                     }
                 }
             }
+            .onAppear() {
+                print("🧾 현재 Playlist 수: \(playlists.count)")
+                for p in playlists {
+                    print("📀 \(p.title) / \(p.createdAt)")
+                }
+            }
 
             .fullScreenCover(isPresented: $isNavigateToScanPoster) {
                 CameraLiveTextView(
@@ -95,6 +103,7 @@ struct MainPosterView: View {
             .ignoresSafeArea()
 //        }
     }
+    
 }
 
 // MARK: PosterViewModelWrapper
@@ -103,21 +112,19 @@ final class PosterViewModelWrapper: ObservableObject {
     @Published var shouldNavigateToMakePlaylist: Bool = false
     @Published var scannedText: RawText? = nil
     var viewModel: any PosterViewModel
-    var playlist: Playlist
     private var cancellables = Set<AnyCancellable>()
-    
-    init(viewModel: any PosterViewModel, playlist: Playlist) {
+
+    init(viewModel: any PosterViewModel) {
         self.viewModel = viewModel
-        self.playlist = playlist
-        
+
         viewModel.shouldNavigateToFestivalCheck.observe(on: self) { [weak self] newData in
             self?.shouldNavigateToFestivalCheck = newData
         }
-        
+
         viewModel.shouldNavigateToMakePlaylist.observe(on: self) { [weak self] newData in
             self?.shouldNavigateToMakePlaylist = newData
         }
-    
+
         viewModel.scannedText.observe(on: self) { [weak self] newData in
             self?.scannedText = newData
         }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
@@ -13,14 +13,14 @@ struct MainPosterView: View {
     @EnvironmentObject var wrapper: PosterViewModelWrapper
     @EnvironmentObject var musicWrapper: MusicViewModelWrapper
     @State private var recognizedText: String = ""
-    @State private var isNavigateToScanPoster = false//ㅂ
+    @State private var isNavigateToScanPoster = false
     @Environment(\.modelContext) var modelContext
     @Query(sort: \Playlist.createdAt, order: .reverse) private var playlists: [Playlist]
     
     
     
     var body: some View {
-//        NavigationStack(path: $navigationPath) {
+        NavigationStack() {
             ZStack(alignment: .bottom) {
                 Color.clear
                     .backgroundWithBlur()
@@ -45,7 +45,7 @@ struct MainPosterView: View {
 
                     } else {
                         VStack {
-                            OverlappingCardsView(playlists: playlists, wrapper: musicWrapper) //임시입니다
+                            OverlappingCardsView(playlists: playlists, wrapper: musicWrapper) //임시입다
                             .padding(.bottom, 12)
                         }
                     }
@@ -85,6 +85,7 @@ struct MainPosterView: View {
                     }
                 }
             }
+            .navigationBarHidden(true)
             .onAppear() {
                 print("🧾 현재 Playlist 수: \(playlists.count)")
                 for p in playlists {
@@ -101,7 +102,7 @@ struct MainPosterView: View {
                 .environmentObject(wrapper)
             }
             .ignoresSafeArea()
-//        }
+        }
     }
     
 }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/OverlappingCardsView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/OverlappingCardsView.swift
@@ -15,12 +15,17 @@ struct OverlappingCardsView: View {
     @State private var imageTimer: Timer?
     @State private var imageIndices: [Int] // 각 플레이리스트의 현재 이미지 인덱스를 추적하기 위한 배열
     @Query var allEntries: [PlaylistEntry]
+    @State private var selectedPlaylist: Playlist?
+    @State private var isNavigateToDetail = false //임시입니다
+    
+    let wrapper: MusicViewModelWrapper //임시입니다.
 
     
-    init(playlists: [Playlist]) {
-        self._playlists = State(initialValue: playlists)
-        self._imageIndices = State(initialValue: Array(repeating: 0, count: playlists.count))
-    }
+    init(playlists: [Playlist], wrapper: MusicViewModelWrapper) {
+           self._playlists = State(initialValue: playlists)
+           self._imageIndices = State(initialValue: Array(repeating: 0, count: playlists.count))
+           self.wrapper = wrapper //임시입니다.
+   }
     
     var body: some View {
         VStack {
@@ -73,11 +78,12 @@ struct OverlappingCardsView: View {
                                 .id(index)
                                 .onTapGesture {
                                     if currentIndex != index {
-                                                currentIndex = index
-                                                proxy.scrollTo(index, anchor: .center)
-                                            } else {
-                                                printPlaylistInfo(playlists[index])
-                                            }
+                                        currentIndex = index
+                                        proxy.scrollTo(index, anchor: .center)
+                                    } else {
+                                        selectedPlaylist = playlist
+                                        isNavigateToDetail = true
+                                    }
                                 }
                             }
                         }
@@ -115,6 +121,21 @@ struct OverlappingCardsView: View {
                         )
                 }
             }
+            NavigationLink( //임시입니다진짜로
+                isActive: $isNavigateToDetail,
+                destination: {
+                    if let selected = selectedPlaylist {
+                        PlaylistDetailView(playlist: selected)
+                            .environmentObject(wrapper)
+                    } else {
+                        EmptyView()
+                    }
+                },
+                label: {
+                    EmptyView()
+                }
+            )
+            .hidden()
         }
     }
     private func printPlaylistInfo(_ playlist: Playlist) {

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/OverlappingCardsView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/OverlappingCardsView.swift
@@ -42,7 +42,7 @@ struct OverlappingCardsView: View {
                                         imageUrl: currentImageURL(for: playlist, at: index),
                                         date: playlist.period ?? "",
                                         title: playlist.title,
-                                        subTitle: playlist.cast ?? playlist.place ?? ""
+                                        subTitle: playlist.place ?? ""
                                     )
                                     .frame(width: cardWidth, height: 420)
                                     .scaleEffect(1.0)

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/OverlappingCardsView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/OverlappingCardsView.swift
@@ -40,12 +40,13 @@ struct OverlappingCardsView: View {
                                     let cardCenter = minX + cardWidth / 2
                                     let distance = abs(cardCenter - screenCenter)
                                     let normalizedDistance = min(distance / (cardWidth / 2), 1.0)
+                                    let matchingEntries = allEntries.filter { $0.playlistId == playlist.id }
                                     
                                     ArtistCard(
                                         imageUrl: currentImageURL(for: playlist, at: index),
                                         date: playlist.period ?? "",
                                         title: playlist.title,
-                                        subTitle: playlist.cast ?? playlist.place ?? ""
+                                        subTitle: "\(matchingEntries.count)곡"
                                     )
                                     .frame(width: cardWidth, height: 420)
                                     .scaleEffect(1.0)

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/OverlappingCardsView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/OverlappingCardsView.swift
@@ -42,7 +42,7 @@ struct OverlappingCardsView: View {
                                         imageUrl: currentImageURL(for: playlist, at: index),
                                         date: playlist.period ?? "",
                                         title: playlist.title,
-                                        subTitle: playlist.place ?? ""
+                                        subTitle: playlist.cast ?? playlist.place ?? ""
                                     )
                                     .frame(width: cardWidth, height: 420)
                                     .scaleEffect(1.0)

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/OverlappingCardsView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/OverlappingCardsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct OverlappingCardsView: View {
     @State private var playlists: [Playlist]
@@ -13,6 +14,8 @@ struct OverlappingCardsView: View {
     @State private var scrollOffset: CGFloat = 0
     @State private var imageTimer: Timer?
     @State private var imageIndices: [Int] // 각 플레이리스트의 현재 이미지 인덱스를 추적하기 위한 배열
+    @Query var allEntries: [PlaylistEntry]
+
     
     init(playlists: [Playlist]) {
         self._playlists = State(initialValue: playlists)
@@ -68,12 +71,12 @@ struct OverlappingCardsView: View {
                                 }
                                 .id(index)
                                 .onTapGesture {
-                                    withAnimation(.easeInOut(duration: 0.5)) {
-                                        if currentIndex != index {
-                                            currentIndex = index
-                                            proxy.scrollTo(index, anchor: .center)
-                                        }
-                                    }
+                                    if currentIndex != index {
+                                                currentIndex = index
+                                                proxy.scrollTo(index, anchor: .center)
+                                            } else {
+                                                printPlaylistInfo(playlists[index])
+                                            }
                                 }
                             }
                         }
@@ -113,13 +116,45 @@ struct OverlappingCardsView: View {
             }
         }
     }
-    
-    private func currentImageURL(for playlist: Playlist, at index: Int) -> String? {
-        let artworkURLs = playlist.entries.compactMap { $0.albumArtworkUrl }
-        guard !artworkURLs.isEmpty, imageIndices[index] < artworkURLs.count else { return nil }
-        return artworkURLs[imageIndices[index]]
+    private func printPlaylistInfo(_ playlist: Playlist) {
+        print("🧾 Playlist 정보")
+        print("🟢 title: \(playlist.title)")
+        print("📍 place: \(playlist.place ?? "nil")")
+        print("📅 period: \(playlist.period ?? "nil")")
+        print("🎤 cast: \(playlist.cast ?? "nil")")
+        print("🆔 id: \(playlist.id)")
+        print("🕒 createdAt: \(playlist.createdAt)")
+
+        let matchingEntries = allEntries.filter { $0.playlistId == playlist.id }
+
+        print("🎶 Entries: (\(matchingEntries.count)곡)")
+        for entry in matchingEntries {
+            print("""
+            ---
+            🎤 artist: \(entry.artistName)
+            artistartwork: \(entry.profileArtworkUrl)
+            🎵 title: \(entry.trackTitle)
+            💿 album: \(entry.albumName)
+            🆔 trackId: \(entry.trackId)
+            🔗 preview: \(entry.trackPreviewUrl)
+            🖼 artwork: \(entry.albumArtworkUrl ?? "nil")
+            📅 createdAt: \(entry.createdAt)
+            """)
+        }
     }
-    
+
+
+    private func currentImageURL(for playlist: Playlist, at index: Int) -> String? {
+        let matchingEntries = allEntries.filter { $0.playlistId == playlist.id }
+        let artworkURLs = matchingEntries.compactMap { $0.profileArtworkUrl }
+
+        guard !artworkURLs.isEmpty else { return nil }
+
+        let currentIdx = imageIndices[index]
+        return artworkURLs[currentIdx % artworkURLs.count]
+    }
+
+
     private func updateCurrentIndex(
         cardGeometry: GeometryProxy,
         index: Int,
@@ -140,18 +175,21 @@ struct OverlappingCardsView: View {
     // 특정 인덱스의 카드 이미지를 다음 이미지로 변경
     private func changeImageForCard(at index: Int) {
         guard index < playlists.count else { return }
-        let artworkURLs = playlists[index].entries.compactMap { $0.albumArtworkUrl }
-        guard !artworkURLs.isEmpty else { return }
-        imageIndices[index] = (imageIndices[index] + 1) % artworkURLs.count
+        let matchingEntries = allEntries.filter { $0.playlistId == playlists[index].id }
+        guard !matchingEntries.isEmpty else { return }
+
+        imageIndices[index] = Int.random(in: 0..<matchingEntries.count)
     }
+
     
     // 2초마다 현재 선택된 카드의 이미지 변경 타이머 시작
     private func startImageTimer() {
         stopImageTimer()
-        imageTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
+        imageTimer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { _ in
             changeImageForCard(at: currentIndex)
         }
     }
+
     
     // 타이머 중지
     private func stopImageTimer() {

--- a/Projects/CodePlay/CodePlay/Presentation/Utils/ArtistCard.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Utils/ArtistCard.swift
@@ -28,24 +28,36 @@ struct ArtistCard: View {
                     .frame(width: 296, height: 296)
                     .background(
                         Group {
-                            
-                            if let imageUrl = imageUrl {
-                                
-                                Image(imageUrl)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 296, height: 296)
-                                    .clipped()
+                            if let imageUrl = imageUrl, let url = URL(string: imageUrl) {
+                                AsyncImage(url: url) { phase in
+                                    switch phase {
+                                    case .empty:
+                                        ProgressView()
+                                            .frame(width: 296, height: 296)
+                                    case .success(let image):
+                                        image
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: 296, height: 296)
+                                            .clipped()
+                                    case .failure:
+                                        Image("ArtistImg")
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(width: 296, height: 296)
+                                    @unknown default:
+                                        EmptyView()
+                                    }
+                                }
                             } else {
-                                
                                 Image("ArtistImg")
                                     .resizable()
-                                    .aspectRatio(contentMode: .fit)
+                                    .scaledToFit()
                                     .frame(width: 296, height: 296)
-                                    .clipped()
                             }
                         }
                     )
+
                     .cornerRadius(16)
                     .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
                 


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #83 

---

### 🧶 주요 변경 내용 (Summary)

- 플레이리스트를 연동합니다
- 아티스트뷰에서 슬라이드쇼가 진행됩니다.
- 아티스트뷰를 누르면 제작했던 셋리스트를 조회합니다.
- 일부 네비게이션을 구현했습니다.

---

### 📸 스크린샷 (Optional)

https://github.com/user-attachments/assets/54a7db0c-25da-4357-a048-692e41149189

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 전 확인해야 할 사항
<!-- PR을 업로드 하기 전에 꼭! 체크해주세요 -->

- [ x ] 코드 컨벤션이 잘 지켜졌나요?
- [ x ] 불필요한 주석, 테스트 코드는 지워져있나요?
- [ x ] 업로드 금지파일이 포함되어있나요?