### PR TITLE
[FIX] MainPosterView 아티스트 썸네일 이미지 캐싱

### DIFF
--- a/Projects/CodePlay/CodePlay.xcodeproj/project.pbxproj
+++ b/Projects/CodePlay/CodePlay.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 				"",
 				"",
 				"",
+				"",
 			);
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Projects/CodePlay/CodePlay/Presentation/Utils/ArtistCard.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Utils/ArtistCard.swift
@@ -56,7 +56,7 @@ struct ArtistCard: View {
                         Group {
                             if let highQualityUrl = highQualityImageUrl,
                                let url = URL(string: highQualityUrl) {
-                                AsyncImage(url: url) { phase in
+                                CachedAsyncImage(url: url) { phase in
                                     switch phase {
                                     case .empty:
                                         ProgressView()
@@ -71,7 +71,7 @@ struct ArtistCard: View {
                                         // 고화질 실패시 원본 URL로 재시도
                                         if let originalUrl = imageUrl,
                                            let fallbackUrl = URL(string: originalUrl) {
-                                            AsyncImage(url: fallbackUrl) { fallbackPhase in
+                                            CachedAsyncImage(url: fallbackUrl) { fallbackPhase in
                                                 switch fallbackPhase {
                                                 case .success(let fallbackImage):
                                                     fallbackImage

--- a/Projects/CodePlay/CodePlay/Presentation/Utils/CachedAsyncImage.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Utils/CachedAsyncImage.swift
@@ -1,0 +1,66 @@
+//
+//  CachedAsyncImage.swift
+//  CodePlay
+//
+//  Created by 광로 on 9/10/25.
+//
+
+import SwiftUI
+internal import Combine
+
+struct CachedAsyncImage<Content: View>: View {
+    let url: URL?
+    let content: (AsyncImagePhase) -> Content
+    
+    @StateObject private var imageLoader = CachedImageLoader()
+    @State private var initialPhase: AsyncImagePhase?
+    
+    init(url: URL?, @ViewBuilder content: @escaping (AsyncImagePhase) -> Content) {
+        self.url = url
+        self.content = content
+    }
+    
+    var body: some View {
+        content(initialPhase ?? imageLoader.phase)
+            .onAppear {
+                if let url = url {
+                    // 즉시 캐시 확인
+                    if let cachedImage = ImageCacheManager.shared.getImage(for: url.absoluteString) {
+                        initialPhase = .success(Image(uiImage: cachedImage))
+                    } else {
+                        imageLoader.loadImage(from: url.absoluteString)
+                    }
+                }
+            }
+            .onChange(of: url) { newUrl in
+                if let newUrl = newUrl {
+                    // URL 변경 시에도 즉시 캐시 확인
+                    if let cachedImage = ImageCacheManager.shared.getImage(for: newUrl.absoluteString) {
+                        initialPhase = .success(Image(uiImage: cachedImage))
+                    } else {
+                        initialPhase = nil
+                        imageLoader.loadImage(from: newUrl.absoluteString)
+                    }
+                }
+            }
+    }
+}
+
+class CachedImageLoader: ObservableObject {
+    @Published var phase: AsyncImagePhase = .empty
+    
+    private let cacheManager = ImageCacheManager.shared
+    
+    func loadImage(from urlString: String) {
+        Task { @MainActor in
+            // 로딩 상태로 설정
+            self.phase = .empty
+            
+            if let image = await cacheManager.loadImage(from: urlString) {
+                self.phase = .success(Image(uiImage: image))
+            } else {
+                self.phase = .failure(URLError(.badURL))
+            }
+        }
+    }
+}

--- a/Projects/CodePlay/CodePlay/Presentation/Utils/ImageCacheManager.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Utils/ImageCacheManager.swift
@@ -1,0 +1,56 @@
+//
+//  ImageCacheManager.swift
+//  CodePlay
+//
+//  Created by 광로 on 9/10/25.
+//
+
+import Foundation
+import UIKit
+
+class ImageCacheManager {
+    static let shared = ImageCacheManager()
+    
+    private let cache = NSCache<NSString, UIImage>()
+    private let urlSession: URLSession
+    
+    private init() {
+        self.urlSession = URLSession.shared
+        cache.countLimit = 150
+        cache.totalCostLimit = 50 * 1024 * 1024
+    }
+    
+    /// 캐시에서 이미지 가져오기
+    func getImage(for url: String) -> UIImage? {
+        return cache.object(forKey: NSString(string: url))
+    }
+    func setImage(_ image: UIImage, for url: String) {
+        cache.setObject(image, forKey: NSString(string: url))
+    }
+    /// URL에서 이미지 로드 (캐시 확인 → 네트워크 → 캐시 저장)
+    func loadImage(from urlString: String) async -> UIImage? {
+        if let cachedImage = getImage(for: urlString) {
+            return cachedImage
+        }
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+        do {
+            let (data, _) = try await urlSession.data(from: url)
+            guard let image = UIImage(data: data) else {
+                return nil
+            }
+            setImage(image, for: urlString)
+            return image
+            
+        } catch {
+            return nil
+        }
+    }
+    func clearCache() {
+        cache.removeAllObjects()
+    }
+    func removeImage(for url: String) {
+        cache.removeObject(forKey: NSString(string: url))
+    }
+}


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #118 


### 🧶 주요 변경 내용 (Summary)

MainPosterView를 들어갈 때 마다 앨범 커버 API가 호출되고 있어서 지연되는 증상

- 이미지 캐싱 시스템을 도입하여 한 번 로드된 이미지를 메모리에 저장하고 재사용

- ImageCacheManager 추가

-> NSCache 기반 메모리 캐싱 (최대 150개 이미지, 50MB 제한) 비동기 이미지 로딩 및 캐시 저장 로직 캐시 관리 기능 (클리어, 개별 삭제)

- CachedAsyncImage 컴포넌트 생성

->  AsyncImage와 동일한 인터페이스로 Drop-in Replacement 캐시 우선 확인 → 즉시 표시 → 
로딩 없음 캐시 없을 때만 네트워크 로딩 수행

- ArtistCard 이미지 로딩 최적화

-> 기존 AsyncImage를 CachedAsyncImage로 교체 고화질 URL 변환 및 폴백 로직 그대로 유지

### 📸 스크린샷 (Optional)

https://github.com/user-attachments/assets/21db7835-5bbf-42be-b14b-38025b71388c



### 🧪 테스트 / 검증 내역

- [x] UI 정상 동작 확인


### 💬 기타 공유 사항

- 처음 페스티벌 라인업 인식 후에 MainPosterView에서 최초에 불러온 이미지에서는 약간의 로딩이 발생 하지만
한번 캐싱된 이미지는 로딩페이지 지연 없이 나오고 있습니다.


### 🙇🏻‍♀️ 리뷰 전 확인해야 할 사항

- [x] 코드 컨벤션이 잘 지켜졌나요?
- [x] 불필요한 주석, 테스트 코드는 지워져있나요?
- [x] 업로드 금지파일이 포함되어있나요?
