### PR TITLE
[REFACTOR] 아키텍쳐 구조 리펙토링

### DIFF
--- a/Projects/CodePlay/CodePlay.xcodeproj/project.pbxproj
+++ b/Projects/CodePlay/CodePlay.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 				"",
 				"",
 				"",
+				"",
 			);
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Projects/CodePlay/CodePlay.xcodeproj/project.pbxproj
+++ b/Projects/CodePlay/CodePlay.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 				"",
 				"",
 				"",
+				"",
 			);
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Projects/CodePlay/CodePlay/Application/DIContainer/MainSceneDIContainer.swift
+++ b/Projects/CodePlay/CodePlay/Application/DIContainer/MainSceneDIContainer.swift
@@ -44,11 +44,9 @@ final class MainSceneDIContainer {
             repository: makeCheckLicenseRepository()
         )
     }
-
-    private func makeExportPlaylistUseCase(repository: ExportPlaylistRepository)
-        -> ExportPlaylistUseCase
-    {
-        return DefaultExportPlaylistUseCase(repository: repository)
+    
+    private func makeExportPlaylistUseCase() -> ExportPlaylistUseCase {
+        return DefaultExportPlaylistUseCase(repository: makeExportPlaylistRepository())
     }
 
     private func makeMusicPlayerUseCase() -> MusicPlayerUseCase {
@@ -101,18 +99,9 @@ final class MainSceneDIContainer {
             fetchFestivalInfoUseCase: makeFestivalUseCase()
         )
     }
-    private func makeExportViewModel(exportRepository: ExportPlaylistRepository)
-        -> any ExportPlaylistViewModel
-    {
-        let exportUseCase = makeExportPlaylistUseCase(
-            repository: exportRepository
-        )
-        let musicPlayerUseCase = makeMusicPlayerUseCase()
-        return DefaultExportPlaylistViewModel(
-            useCase: exportUseCase,
-            musicPlayerUseCase: musicPlayerUseCase,
-            modelContext: modelContext
-        )
+    
+    private func makeExportViewModel() -> any ExportPlaylistViewModel {
+        DefaultExportPlaylistViewModel(useCase: makeExportPlaylistUseCase(), musicPlayerUseCase: makeMusicPlayerUseCase(), modelContext: modelContext)
     }
 
     // MARK: ViewModelWrapper
@@ -123,14 +112,9 @@ final class MainSceneDIContainer {
     }
 
     func appleMusicConnectViewModelWrapper() -> MusicViewModelWrapper {
-        let exportRepository = makeExportPlaylistRepository()
-        let exportViewModel = makeExportViewModel(
-            exportRepository: exportRepository
-        )
-
         return MusicViewModelWrapper(
             appleMusicConnectViewModel: appleMusicConnectViewModel(),
-            exportViewModelWrapper: exportViewModel,
+            exportPlaylistViewModel: makeExportViewModel(),
             festivalCheckViewModel: makeFestivalCheckViewModel()
         )
     }

--- a/Projects/CodePlay/CodePlay/Application/DIContainer/MainSceneDIContainer.swift
+++ b/Projects/CodePlay/CodePlay/Application/DIContainer/MainSceneDIContainer.swift
@@ -107,8 +107,10 @@ final class MainSceneDIContainer {
         let exportUseCase = makeExportPlaylistUseCase(
             repository: exportRepository
         )
+        let musicPlayerUseCase = makeMusicPlayerUseCase()
         return DefaultExportPlaylistViewModel(
             useCase: exportUseCase,
+            musicPlayerUseCase: musicPlayerUseCase,
             modelContext: modelContext
         )
     }
@@ -125,13 +127,11 @@ final class MainSceneDIContainer {
         let exportViewModel = makeExportViewModel(
             exportRepository: exportRepository
         )
-        let musicPlayerUseCase = makeMusicPlayerUseCase()
 
         return MusicViewModelWrapper(
             appleMusicConnectViewModel: appleMusicConnectViewModel(),
             exportViewModelWrapper: exportViewModel,
-            festivalCheckViewModel: makeFestivalCheckViewModel(),
-            musicPlayerUseCase: musicPlayerUseCase
+            festivalCheckViewModel: makeFestivalCheckViewModel()
         )
     }
 }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportPlaylistView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/ExportPlaylistView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-internal import Combine
+import Combine
 import MusicKit
 
 

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/FestivalCheck/FestivalView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/FestivalCheck/FestivalView.swift
@@ -5,7 +5,7 @@
 //  Created by 아우신얀 on 7/29/25.
 //
 
-internal import Combine
+import Combine
 import SwiftData
 import SwiftUI
 

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/MadePlaylistView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/View/MadePlaylistView.swift
@@ -8,12 +8,6 @@
 import SwiftData
 import SwiftUI
 
-// MARK: 진입점 여부 판단
-enum PlaylistEntrySource {
-    case main
-    case export
-}
-
 struct MadePlaylistView: View {
     @EnvironmentObject var posterWrapper: PosterViewModelWrapper
     @EnvironmentObject var wrapper: MusicViewModelWrapper

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/ExportPlaylistViewModel.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/ExportPlaylistViewModel.swift
@@ -6,7 +6,7 @@
 //
 import Foundation
 import SwiftData
-internal import Combine
+import Combine
 
 // MARK: - Input
 protocol ExportPlaylistViewModelInput {

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/ExportPlaylistViewModel.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/ExportPlaylistViewModel.swift
@@ -16,16 +16,22 @@ protocol ExportPlaylistViewModel {
     func searchTopSongsWithCaching(from rawText: RawText, artistMatches: [ArtistMatch], musicPlayerUseCase: MusicPlayerUseCase) async -> [PlaylistEntry]  // 캐싱과 함께 인기곡 검색
     func exportLatestPlaylistToAppleMusic() async  // 애플뮤직으로 플레이리스트 전송
     func deletePlaylistEntry(trackId: String) async  // 플레이리스트에서 특정 항목 삭제
+
+    func setupMusicPlayerCallbacks(onPlaybackStateChanged: @escaping (String?, Bool) -> Void, onProgressChanged: @escaping (Double) -> Void)
+    func togglePreview(for trackId: String) async
+    func stopPreview() async
 }
 
 final class DefaultExportPlaylistViewModel: ExportPlaylistViewModel {
     private let useCase: ExportPlaylistUseCase
+    private let musicPlayerUseCase: MusicPlayerUseCase
     private let modelContext: ModelContext
 
     var artistCandidates: Observable<[String]> = Observable([])
 
-    init(useCase: ExportPlaylistUseCase, modelContext: ModelContext) {
+    init(useCase: ExportPlaylistUseCase, musicPlayerUseCase: MusicPlayerUseCase, modelContext: ModelContext) {
         self.useCase = useCase
+        self.musicPlayerUseCase = musicPlayerUseCase
         self.modelContext = modelContext
     }
 
@@ -55,7 +61,8 @@ final class DefaultExportPlaylistViewModel: ExportPlaylistViewModel {
         )) ?? []
     }
 
-    func exportLatestPlaylistToAppleMusic() async {  // 추후 Repository로 이동해야할 듯 합니다.
+    // TODO: 추후 Repository로 이동해야할 듯 합니다.
+    func exportLatestPlaylistToAppleMusic() async {
         await MainActor.run {
             do {
                 guard
@@ -87,5 +94,18 @@ final class DefaultExportPlaylistViewModel: ExportPlaylistViewModel {
     
     func deletePlaylistEntry(trackId: String) async {
         await useCase.deletePlaylistEntry(trackId: trackId)
+    }
+
+    // MARK: - Music Player functionality
+    func setupMusicPlayerCallbacks(onPlaybackStateChanged: @escaping (String?, Bool) -> Void, onProgressChanged: @escaping (Double) -> Void) {
+        musicPlayerUseCase.setupRepositoryCallbacks(onPlaybackStateChanged: onPlaybackStateChanged, onProgressChanged: onProgressChanged)
+    }
+
+    func togglePreview(for trackId: String) async {
+        await musicPlayerUseCase.musicRepository.togglePreview(for: trackId)
+    }
+
+    func stopPreview() async {
+        await musicPlayerUseCase.stopPreview()
     }
 }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/ExportPlaylistViewModel.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/ExportPlaylistViewModel.swift
@@ -7,6 +7,7 @@
 import Foundation
 import SwiftData
 
+// MARK: ExportPlaylistViewModel
 protocol ExportPlaylistViewModel {
     func preProcessRawText(_ rawText: RawText)  // 텍스트를 띄어쓰기에 맞춰서 여러개 쪼개고, 하나의 데이터로 저장하는 로직 (RawText 업데이트)
     var artistCandidates: Observable<[String]> { get }  // 아티스트 스트링 관리, 추후 리펙토링 필요
@@ -16,23 +17,38 @@ protocol ExportPlaylistViewModel {
     func searchTopSongsWithCaching(from rawText: RawText, artistMatches: [ArtistMatch], musicPlayerUseCase: MusicPlayerUseCase) async -> [PlaylistEntry]  // 캐싱과 함께 인기곡 검색
     func exportLatestPlaylistToAppleMusic() async  // 애플뮤직으로 플레이리스트 전송
     func deletePlaylistEntry(trackId: String) async  // 플레이리스트에서 특정 항목 삭제
-
-    func setupMusicPlayerCallbacks(onPlaybackStateChanged: @escaping (String?, Bool) -> Void, onProgressChanged: @escaping (Double) -> Void)
     func togglePreview(for trackId: String) async
     func stopPreview() async
 }
 
+// MARK: DefaultExportPlaylistViewModel
 final class DefaultExportPlaylistViewModel: ExportPlaylistViewModel {
     private let useCase: ExportPlaylistUseCase
     private let musicPlayerUseCase: MusicPlayerUseCase
     private let modelContext: ModelContext
 
     var artistCandidates: Observable<[String]> = Observable([])
+    var currentlyPlayingTrackId: Observable<String?> = Observable(nil)
+    var isPlaying: Observable<Bool> = Observable(false)
+    var playbackProgress: Observable<Double> = Observable(0.0)
 
     init(useCase: ExportPlaylistUseCase, musicPlayerUseCase: MusicPlayerUseCase, modelContext: ModelContext) {
         self.useCase = useCase
         self.musicPlayerUseCase = musicPlayerUseCase
         self.modelContext = modelContext
+        setupMusicPlayerCallbacks()
+    }
+
+    private func setupMusicPlayerCallbacks() {
+        musicPlayerUseCase.setupRepositoryCallbacks(
+            onPlaybackStateChanged: { [weak self] trackId, isPlaying in
+                self?.currentlyPlayingTrackId.value = trackId
+                self?.isPlaying.value = isPlaying
+            },
+            onProgressChanged: { [weak self] progress in
+                self?.playbackProgress.value = progress
+            }
+        )
     }
 
     func preProcessRawText(_ rawText: RawText) {
@@ -94,11 +110,6 @@ final class DefaultExportPlaylistViewModel: ExportPlaylistViewModel {
     
     func deletePlaylistEntry(trackId: String) async {
         await useCase.deletePlaylistEntry(trackId: trackId)
-    }
-
-    // MARK: - Music Player functionality
-    func setupMusicPlayerCallbacks(onPlaybackStateChanged: @escaping (String?, Bool) -> Void, onProgressChanged: @escaping (Double) -> Void) {
-        musicPlayerUseCase.setupRepositoryCallbacks(onPlaybackStateChanged: onPlaybackStateChanged, onProgressChanged: onProgressChanged)
     }
 
     func togglePreview(for trackId: String) async {

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/ExportPlaylistViewModel.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/ExportPlaylistViewModel.swift
@@ -6,11 +6,11 @@
 //
 import Foundation
 import SwiftData
+internal import Combine
 
-// MARK: ExportPlaylistViewModel
-protocol ExportPlaylistViewModel {
+// MARK: - Input
+protocol ExportPlaylistViewModelInput {
     func preProcessRawText(_ rawText: RawText)  // 텍스트를 띄어쓰기에 맞춰서 여러개 쪼개고, 하나의 데이터로 저장하는 로직 (RawText 업데이트)
-    var artistCandidates: Observable<[String]> { get }  // 아티스트 스트링 관리, 추후 리펙토링 필요
     func searchArtists(from rawText: RawText) async -> [ArtistMatch]  // RawText를 한줄한줄 검색해 매칭된 아티스트 저장
     func searchTopSongs(from rawText: RawText, artistMatches: [ArtistMatch])
         async -> [PlaylistEntry]  // ArtistMatch에서 노래를 검색하고, PlaylistEntry로 저장
@@ -20,6 +20,17 @@ protocol ExportPlaylistViewModel {
     func togglePreview(for trackId: String) async
     func stopPreview() async
 }
+
+// MARK: - Output
+protocol ExportPlaylistViewModelOutput {
+    var artistCandidates: Observable<[String]> { get }  // 아티스트 스트링 관리, 추후 리펙토링 필요
+    var currentlyPlayingTrackId: Observable<String?> { get }  // 현재 재생 중인 트랙 ID
+    var isPlaying: Observable<Bool> { get }  // 재생 상태
+    var playbackProgress: Observable<Double> { get }  // 재생 진행률
+}
+
+// MARK: - ExportPlaylistViewModel
+protocol ExportPlaylistViewModel: ExportPlaylistViewModelInput, ExportPlaylistViewModelOutput, ObservableObject {}
 
 // MARK: DefaultExportPlaylistViewModel
 final class DefaultExportPlaylistViewModel: ExportPlaylistViewModel {

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/FestivalCheckViewModel.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/FestivalCheckViewModel.swift
@@ -8,14 +8,6 @@
 import Combine
 import Foundation
 
-enum FestivalFetchState {
-    case idle
-    case loading
-    case success(PostFestInfoResponseDTO)
-    case noResult
-    case error(String)
-}
-
 // MARK: - Input
 protocol FestivalCheckViewModelInput {
     func loadFestivalInfo(from rawText: String) async

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/FestivalCheckViewModel.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/ExportPlaylist/ViewModel/FestivalCheckViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by 아우신얀 on 7/28/25.
 //
 
-internal import Combine
+import Combine
 import Foundation
 
 enum FestivalFetchState {

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
@@ -5,7 +5,7 @@
 //  Created by 성현 on 7/15/25.
 //
 
-internal import Combine
+import Combine
 import MusicKit
 import SwiftData
 import SwiftUI

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
@@ -128,17 +128,17 @@ final class MusicViewModelWrapper: ObservableObject {
 
     // MARK: - Dependencies
     var appleMusicConnectViewModel: any AppleMusicConnectViewModel
-    var exportViewModelWrapper: any ExportPlaylistViewModel
+    var exportPlaylistViewModel: any ExportPlaylistViewModel
     var festivalCheckViewModel: any FestivalCheckViewModel
 
     // MARK: - Init
     init(
         appleMusicConnectViewModel: any AppleMusicConnectViewModel,
-        exportViewModelWrapper: any ExportPlaylistViewModel,
+        exportPlaylistViewModel: any ExportPlaylistViewModel,
         festivalCheckViewModel: any FestivalCheckViewModel
     ) {
         self.appleMusicConnectViewModel = appleMusicConnectViewModel
-        self.exportViewModelWrapper = exportViewModelWrapper
+        self.exportPlaylistViewModel = exportPlaylistViewModel
         self.festivalCheckViewModel = festivalCheckViewModel
 
         bind()
@@ -195,7 +195,7 @@ final class MusicViewModelWrapper: ObservableObject {
             }
         }
 
-        exportViewModelWrapper.artistCandidates.observe(on: self) {
+        exportPlaylistViewModel.artistCandidates.observe(on: self) {
             [weak self] value in
             guard let self else { return }
             Task { @MainActor in
@@ -203,7 +203,7 @@ final class MusicViewModelWrapper: ObservableObject {
             }
         }
 
-        exportViewModelWrapper.currentlyPlayingTrackId.observe(on: self) {
+        exportPlaylistViewModel.currentlyPlayingTrackId.observe(on: self) {
             [weak self] trackId in
             guard let self else { return }
             Task { @MainActor in
@@ -211,7 +211,7 @@ final class MusicViewModelWrapper: ObservableObject {
             }
         }
 
-        exportViewModelWrapper.isPlaying.observe(on: self) {
+        exportPlaylistViewModel.isPlaying.observe(on: self) {
             [weak self] isPlaying in
             guard let self else { return }
             Task { @MainActor in
@@ -219,7 +219,7 @@ final class MusicViewModelWrapper: ObservableObject {
             }
         }
 
-        exportViewModelWrapper.playbackProgress.observe(on: self) {
+        exportPlaylistViewModel.playbackProgress.observe(on: self) {
             [weak self] progress in
             DispatchQueue.main.async {
                 self?.playbackProgress = progress
@@ -240,7 +240,7 @@ final class MusicViewModelWrapper: ObservableObject {
             self.progressStep = 0
         }
 
-        exportViewModelWrapper.preProcessRawText(rawText)
+        exportPlaylistViewModel.preProcessRawText(rawText)
 
         await MainActor.run {
             withAnimation(.easeInOut(duration: 0.5)) {
@@ -248,7 +248,7 @@ final class MusicViewModelWrapper: ObservableObject {
             }
         }
 
-        let matches = await exportViewModelWrapper.searchArtists(from: rawText)
+        let matches = await exportPlaylistViewModel.searchArtists(from: rawText)
         Log.debug("🔍 [searchArtists] 매칭된 아티스트 수: \(matches.count)")
         matches.forEach { Log.debug("🎤 \($0.artistName) (\($0.appleMusicId))") }
 
@@ -258,7 +258,7 @@ final class MusicViewModelWrapper: ObservableObject {
             }
         }
 
-        let songs = await exportViewModelWrapper.searchTopSongs(
+        let songs = await exportPlaylistViewModel.searchTopSongs(
             from: rawText,
             artistMatches: matches
         )
@@ -318,7 +318,7 @@ final class MusicViewModelWrapper: ObservableObject {
     func exportToAppleMusic() {
         isExporting = true
         Task {
-            await exportViewModelWrapper.exportLatestPlaylistToAppleMusic()
+            await exportPlaylistViewModel.exportLatestPlaylistToAppleMusic()
             DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
                 self.isExporting = false
                 self.isExportCompleted = true
@@ -345,9 +345,9 @@ final class MusicViewModelWrapper: ObservableObject {
         Task {
             // 현재 재생 중인 곡이라면 먼저 음악 정지
             if currentlyPlayingTrackId == trackId {
-                await exportViewModelWrapper.stopPreview()
+                await exportPlaylistViewModel.stopPreview()
             }
-            await exportViewModelWrapper.deletePlaylistEntry(trackId: trackId)
+            await exportPlaylistViewModel.deletePlaylistEntry(trackId: trackId)
             await MainActor.run {
                 if currentlyPlayingTrackId == trackId {
                     currentlyPlayingTrackId = nil
@@ -367,7 +367,7 @@ final class MusicViewModelWrapper: ObservableObject {
 
     func togglePreview(for trackId: String) {
         Task {
-            await exportViewModelWrapper.togglePreview(for: trackId)
+            await exportPlaylistViewModel.togglePreview(for: trackId)
         }
     }
 }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
@@ -131,19 +131,16 @@ final class MusicViewModelWrapper: ObservableObject {
     var appleMusicConnectViewModel: any AppleMusicConnectViewModel
     var exportViewModelWrapper: any ExportPlaylistViewModel
     var festivalCheckViewModel: any FestivalCheckViewModel
-    private var musicPlayerUseCase: MusicPlayerUseCase
 
     // MARK: - Init
     init(
         appleMusicConnectViewModel: any AppleMusicConnectViewModel,
         exportViewModelWrapper: any ExportPlaylistViewModel,
-        festivalCheckViewModel: any FestivalCheckViewModel,
-        musicPlayerUseCase: MusicPlayerUseCase
+        festivalCheckViewModel: any FestivalCheckViewModel
     ) {
         self.appleMusicConnectViewModel = appleMusicConnectViewModel
         self.exportViewModelWrapper = exportViewModelWrapper
         self.festivalCheckViewModel = festivalCheckViewModel
-        self.musicPlayerUseCase = musicPlayerUseCase
 
         bind()
     }
@@ -155,8 +152,8 @@ final class MusicViewModelWrapper: ObservableObject {
             guard let self else { return }
             DispatchQueue.main.async {
                 self.isLoading = value
-                // UseCase를 통해 Repository 콜백 설정
-                self.musicPlayerUseCase.setupRepositoryCallbacks(
+                // ViewModel을 통해 Repository 콜백 설정
+                self.exportViewModelWrapper.setupMusicPlayerCallbacks(
                     onPlaybackStateChanged: { [weak self] trackId, isPlaying in
                         DispatchQueue.main.async {
                             self?.currentlyPlayingTrackId = trackId
@@ -167,7 +164,7 @@ final class MusicViewModelWrapper: ObservableObject {
                         DispatchQueue.main.async {
                             self?.playbackProgress = progress
                         }
-                    },
+                    }
                 )
             }
         }
@@ -222,7 +219,7 @@ final class MusicViewModelWrapper: ObservableObject {
             }
         }
 
-        musicPlayerUseCase.setupRepositoryCallbacks(
+        exportViewModelWrapper.setupMusicPlayerCallbacks(
             onPlaybackStateChanged: { [weak self] trackId, isPlaying in
                 guard let self else { return }
                 Task { @MainActor in
@@ -356,7 +353,7 @@ final class MusicViewModelWrapper: ObservableObject {
         Task {
             // 현재 재생 중인 곡이라면 먼저 음악 정지
             if currentlyPlayingTrackId == trackId {
-                await musicPlayerUseCase.stopPreview()
+                await exportViewModelWrapper.stopPreview()
             }
             await exportViewModelWrapper.deletePlaylistEntry(trackId: trackId)
             await MainActor.run {
@@ -378,7 +375,7 @@ final class MusicViewModelWrapper: ObservableObject {
 
     func togglePreview(for trackId: String) {
         Task {
-            await musicPlayerUseCase.musicRepository.togglePreview(for: trackId)
+            await exportViewModelWrapper.togglePreview(for: trackId)
         }
     }
 }

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/View/AppleMusicConnectView.swift
@@ -120,7 +120,6 @@ final class MusicViewModelWrapper: ObservableObject {
     @Published var festivalData: DynamoDataItem? = nil
     @Published var suggestTitles: [String] = []
     @Published var selectedPlaylist: Playlist? = nil
-//    @Published var shouldShowNoResultView: Bool = false
     var shouldShowNoResultView: Bool = false
     @Published var showErrorView: Bool = false
     @Published var entrySource: PlaylistEntrySource = .main
@@ -149,23 +148,8 @@ final class MusicViewModelWrapper: ObservableObject {
     private func bind() {
         festivalCheckViewModel.isLoading.observe(on: self) {
             [weak self] value in
-            guard let self else { return }
             DispatchQueue.main.async {
-                self.isLoading = value
-                // ViewModel을 통해 Repository 콜백 설정
-                self.exportViewModelWrapper.setupMusicPlayerCallbacks(
-                    onPlaybackStateChanged: { [weak self] trackId, isPlaying in
-                        DispatchQueue.main.async {
-                            self?.currentlyPlayingTrackId = trackId
-                            self?.isPlaying = isPlaying
-                        }
-                    },
-                    onProgressChanged: { [weak self] progress in
-                        DispatchQueue.main.async {
-                            self?.playbackProgress = progress
-                        }
-                    }
-                )
+                self?.isLoading = value
             }
         }
 
@@ -219,20 +203,28 @@ final class MusicViewModelWrapper: ObservableObject {
             }
         }
 
-        exportViewModelWrapper.setupMusicPlayerCallbacks(
-            onPlaybackStateChanged: { [weak self] trackId, isPlaying in
-                guard let self else { return }
-                Task { @MainActor in
-                    self.currentlyPlayingTrackId = trackId
-                    self.isPlaying = isPlaying
-                }
-            },
-            onProgressChanged: { [weak self] progress in
-                DispatchQueue.main.async {
-                    self?.playbackProgress = progress
-                }
+        exportViewModelWrapper.currentlyPlayingTrackId.observe(on: self) {
+            [weak self] trackId in
+            guard let self else { return }
+            Task { @MainActor in
+                self.currentlyPlayingTrackId = trackId
             }
-        )
+        }
+
+        exportViewModelWrapper.isPlaying.observe(on: self) {
+            [weak self] isPlaying in
+            guard let self else { return }
+            Task { @MainActor in
+                self.isPlaying = isPlaying
+            }
+        }
+
+        exportViewModelWrapper.playbackProgress.observe(on: self) {
+            [weak self] progress in
+            DispatchQueue.main.async {
+                self?.playbackProgress = progress
+            }
+        }
     }
 
     // MARK: - Main Flow

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/ViewModel/AppleMusicConnectViewModel.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/ViewModel/AppleMusicConnectViewModel.swift
@@ -33,7 +33,6 @@ protocol AppleMusicConnectViewModel: AppleMusicConnectViewModelInput,
 
 // MARK: - Implementation
 final class DefaultAppleMusicConnectViewModel: AppleMusicConnectViewModel {
-    // MARK: Output
     var authorizationStatus: Observable<MusicAuthorizationStatusModel?> =
         Observable(nil)
     var subscriptionStatus: Observable<MusicSubscriptionModel?> = Observable(
@@ -46,14 +45,12 @@ final class DefaultAppleMusicConnectViewModel: AppleMusicConnectViewModel {
 
     private let checkLicenseUseCase: CheckLicenseUseCase
 
-    // MARK: Init
     init(checkLicenseUseCase: CheckLicenseUseCase) {
         self.checkLicenseUseCase = checkLicenseUseCase
         observeTriggers()
         updateMusicAuthorizationStatus()
     }
 
-    // MARK: Input
     func requestMusicAuthorization() {
         Task {
             do {
@@ -114,7 +111,6 @@ final class DefaultAppleMusicConnectViewModel: AppleMusicConnectViewModel {
         checkLicenseUseCase.openSettings()
     }
 
-    // MARK: Private Helpers
     private func updateCanPlayMusic() {
         let isAuthorized = authorizationStatus.value?.isAuthorized ?? false
         let hasSubscription = subscriptionStatus.value?.canPlayMusic ?? false

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/ViewModel/AppleMusicConnectViewModel.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/LicenseCheck/ViewModel/AppleMusicConnectViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by 성현 on 7/15/25.
 //
 
-internal import Combine
+import Combine
 import Foundation
 
 // MARK: - Input

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/View/MainPosterView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-internal import Combine
+import Combine
 import SwiftData
 
 struct MainPosterView: View {

--- a/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/ViewModel/PosterViewModel.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Scene/MainPosterView/ViewModel/PosterViewModel.swift
@@ -6,7 +6,7 @@
 //
 import Foundation
 import UIKit
-internal import Combine
+import Combine
 
 // MARK: PosterViewModelInput
 protocol PosterViewModelInput {

--- a/Projects/CodePlay/CodePlay/Presentation/Utils/CachedAsyncImage.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Utils/CachedAsyncImage.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-internal import Combine
+import Combine
 
 struct CachedAsyncImage<Content: View>: View {
     let url: URL?

--- a/Projects/CodePlay/CodePlay/Presentation/Utils/Enums.swift
+++ b/Projects/CodePlay/CodePlay/Presentation/Utils/Enums.swift
@@ -1,0 +1,23 @@
+//
+//  Enums.swift
+//  CodePlay
+//
+//  Created by 신얀 on 9/17/25.
+//
+
+import Foundation
+
+// MARK: - 진입점 여부 판단
+enum PlaylistEntrySource {
+    case main
+    case export
+}
+
+// MARK: - 페스티벌 데이터 로딩 상태
+enum FestivalFetchState {
+    case idle
+    case loading
+    case success(PostFestInfoResponseDTO)
+    case noResult
+    case error(String)
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #109 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

1️⃣ 아키텍쳐 리펙토링
 AppleMusicConnectView 에 있던 MusicViewModelWrapper내부에서 usecase를 의존하던 로직을 exportPlaylistViewModel에 통합하였습니다. (잘못된 방향 - viewModelWrapper가 usecase를 향하고 있음)

 exportPlaylistViewModel에서 음악 플레이어 부분을 콜백으로 상태를 넘기고 있는데 이미 observe 패턴을 사용하고 있으므로 콜백 부분이 불필요하다고 판단하였습니다. 콜백으로 상태가 관리되면서 프로토콜안에 너무 많은 변수와함수가 관리되어 exportViewModel 안에 input/output 프로토콜을 지정하였습니다
- input: 비즈니스 로직이 실행될 수 있도록 함수들을 포함
- output: 다른 파일이 속성에 접근할 수 있도록 observable 변수들을 output에 포함시켜 상태를 관찰하도록 한다.

2️⃣ enum 관리
뷰와 뷰모델 파일에 혼잡하게 섞여있던 enum 타입을 따로 뺴서 한 파일에 관리하도록 분리 하였습니다
- 파일 위치: Presentation/Utils/Enums 

3️⃣ internal import Combine 제거
import Combine이 해결 안되던 문제를 해결했습니다..
문제 원인은 SPM이랑 DerivedData가 꼬이면서 컴파일러가 combine을 인식하지 못했던거 였는데 파생데이터 지워주고 패키지 다시 다운로드 해주니까 해결됐습니다~ 

이제 internal 안써도 됩니다!!

- 

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

x

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

x

---

### 🙇🏻‍♀️ 리뷰 전 확인해야 할 사항
<!-- PR을 업로드 하기 전에 꼭! 체크해주세요 -->

- [x] 코드 컨벤션이 잘 지켜졌나요?
- [x] 불필요한 주석, 테스트 코드는 지워져있나요?
- [x] 업로드 금지파일이 포함되어있나요?
